### PR TITLE
Contact page refactor

### DIFF
--- a/src/components/editorial/ContactDetails.astro
+++ b/src/components/editorial/ContactDetails.astro
@@ -1,0 +1,35 @@
+---
+interface ContactLink {
+	label: string;
+	text: string;
+	href: string;
+	external?: boolean;
+}
+
+interface Props {
+	eyebrow: string;
+	links: ContactLink[];
+}
+
+const { eyebrow, links } = Astro.props;
+---
+
+<section class="contact-details">
+	<p class="contact-details__eyebrow">{eyebrow}</p>
+	<div class="contact-details__list">
+		{links.map((link) => (
+			<div class="contact-detail-row">
+				<p class="contact-detail-row__label">{link.label}</p>
+				<a
+					class="contact-detail-row__link"
+					href={link.href}
+					target={link.external ? '_blank' : undefined}
+					rel={link.external ? 'noopener noreferrer' : undefined}
+					aria-label={link.external ? `${link.text} (opens in new tab)` : undefined}
+				>
+					{link.text}{link.external && <span aria-hidden="true"> ↗</span>}
+				</a>
+			</div>
+		))}
+	</div>
+</section>

--- a/src/components/editorial/ConversationPrompts.astro
+++ b/src/components/editorial/ConversationPrompts.astro
@@ -1,0 +1,25 @@
+---
+interface Prompt {
+	label: string;
+	title: string;
+	body: string;
+}
+
+interface Props {
+	prompts: Prompt[];
+}
+
+const { prompts } = Astro.props;
+---
+
+<section class="conversation-prompts">
+	<div class="conversation-prompts__grid">
+		{prompts.map((p) => (
+			<div class="conversation-prompt">
+				<p class="conversation-prompt__label">{p.label}</p>
+				<h2 class="conversation-prompt__title">{p.title}</h2>
+				<p class="conversation-prompt__body">{p.body}</p>
+			</div>
+		))}
+	</div>
+</section>

--- a/src/components/editorial/PageIntro.astro
+++ b/src/components/editorial/PageIntro.astro
@@ -12,4 +12,7 @@ const { eyebrow, headline, deck } = Astro.props;
 	<p class="page-intro__eyebrow">{eyebrow}</p>
 	<h1 class="page-intro__headline">{headline}</h1>
 	<p class="page-intro__deck">{deck}</p>
+	<div class="page-intro__cta">
+		<slot name="cta" />
+	</div>
 </section>

--- a/src/layouts/ShowcaseLayout.astro
+++ b/src/layouts/ShowcaseLayout.astro
@@ -42,7 +42,7 @@ const footerLinks: NavItem[] = [
 	{ href: 'https://maggielynn.substack.com/', label: 'Field Notes', external: true },
 	{ href: '/work', label: 'Work' },
 	{ href: '/contact', label: 'Contact' },
-	{ href: '#', label: 'LinkedIn' }
+	{ href: 'https://www.linkedin.com/in/maggiemlynn/', label: 'LinkedIn', external: true }
 ];
 
 const currentPath = Astro.url.pathname.replace(/\/$/, '') || '/';

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,33 +1,68 @@
 ---
 import ShowcaseLayout from '../layouts/ShowcaseLayout.astro';
+import PageIntro from '../components/editorial/PageIntro.astro';
+import ConversationPrompts from '../components/editorial/ConversationPrompts.astro';
+import ContactDetails from '../components/editorial/ContactDetails.astro';
 ---
 
 <ShowcaseLayout
 	title="Contact"
-	description="A placeholder contact page for inquiries, collaborations, and direct outreach."
+	description="Start a conversation. I'm open to senior leadership roles, speaking invitations, and conversations about strategic implementation, transformation, and operating systems."
+	noHero={true}
 >
-	<div class="section-heading">
-		<p class="section-heading__eyebrow">Access</p>
-		<div class="section-heading__line"></div>
-		<span class="section-heading__label">Inquiry structure</span>
-	</div>
-	<section class="content-panel content-panel--split">
-		<header class="content-panel__header">
-			<p class="content-panel__eyebrow">Inquiries</p>
-			<h2 class="content-panel__title">Direct outreach and collaboration intake.</h2>
-		</header>
-		<div class="content-panel__content">
-			<p class="content-panel__body">
-			Use this page for email, scheduling, social links, or any preferred intake method for new
-			conversations.
-			</p>
-		</div>
-		<div class="content-panel__content">
-			<ul class="content-panel__list">
-				<li>Primary contact method</li>
-				<li>Response window or availability</li>
-				<li>Project or speaking intake details</li>
-			</ul>
-		</div>
-	</section>
+	<PageIntro
+		eyebrow="Contact"
+		headline="Start a conversation."
+		deck="I\u2019m open to senior leadership roles, speaking invitations, and conversations about the messy, important work of turning strategy into execution\u2014operations, transformation, and the systems that make complex work actually hold together."
+	>
+		<Fragment slot="cta">
+			<a class="interface-button interface-button--primary" href="mailto:maggie@reasonablepeople.io">
+				<span>Email Maggie</span>
+			</a>
+			<a class="page-intro__email" href="mailto:maggie@reasonablepeople.io">
+				maggie@reasonablepeople.io
+			</a>
+		</Fragment>
+	</PageIntro>
+
+	<ConversationPrompts
+		prompts={[
+			{
+				label: 'Leadership',
+				title: 'Senior leadership',
+				body: "I\u2019m interested in roles spanning strategic operations, transformation, portfolio leadership, and the work of turning consequential priorities into sustained execution."
+			},
+			{
+				label: 'Speaking',
+				title: 'Talks + workshops',
+				body: 'I speak about strategic implementation, trust, delivery experience, risk, decision-making, and the systems that shape how complex work actually feels.'
+			},
+			{
+				label: 'Conversation',
+				title: 'Something interesting',
+				body: "If you\u2019re sitting with a messy, high-stakes problem\u2014strategy that won\u2019t land; execution that keeps stalling; adoption that looks good on paper but doesn\u2019t hold in practice\u2014those are my favorite kinds of conversations."
+			}
+		]}
+	/>
+
+	<ContactDetails
+		eyebrow="Elsewhere"
+		links={[
+			{
+				label: 'Email',
+				text: 'maggie@reasonablepeople.io',
+				href: 'mailto:maggie@reasonablepeople.io'
+			},
+			{
+				label: 'LinkedIn',
+				text: 'Connect on LinkedIn',
+				href: 'https://www.linkedin.com/in/maggiemlynn/',
+				external: true
+			}
+		]}
+	/>
+
+	<p class="contact-closing">
+		Good work usually starts with someone saying, \u201cHere\u2019s the weird part.\u201d
+	</p>
 </ShowcaseLayout>

--- a/src/styles/foundation.css
+++ b/src/styles/foundation.css
@@ -3323,3 +3323,170 @@ details[open] .artifact-figure__trigger-label::before {
   gap: var(--space-24);
   align-items: center;
 }
+
+/* ─── PageIntro CTA slot ────────────────────────────────── */
+
+.page-intro__cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-12) var(--space-24);
+  align-items: center;
+  min-height: 0;
+}
+
+.page-intro__cta:empty {
+  display: none;
+}
+
+.page-intro__email {
+  font-size: 0.95rem;
+  color: var(--color-muted);
+  text-decoration: none;
+  border-bottom: 1px solid rgba(107, 98, 88, 0.4);
+  transition: color 180ms ease, border-color 180ms ease;
+}
+
+.page-intro__email:hover,
+.page-intro__email:focus-visible {
+  color: var(--color-ink);
+  border-color: var(--color-ink);
+}
+
+.page-intro__email:focus-visible {
+  outline: 2px solid var(--color-oxblood);
+  outline-offset: var(--space-4);
+}
+
+/* ─── ConversationPrompts ───────────────────────────────── */
+
+.conversation-prompts {
+  padding: var(--space-48) 0;
+  border-top: 1px solid var(--color-rule);
+  border-bottom: 1px solid var(--color-rule);
+}
+
+.conversation-prompts__grid {
+  display: grid;
+  gap: var(--space-48);
+}
+
+@media (min-width: 48rem) {
+  .conversation-prompts__grid {
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--space-32);
+  }
+}
+
+.conversation-prompt {
+  display: grid;
+  gap: var(--space-12);
+  align-content: start;
+  padding-top: var(--space-16);
+  border-top: 1px solid var(--color-rule);
+}
+
+@media (min-width: 48rem) {
+  .conversation-prompt {
+    border-top: none;
+    padding-top: 0;
+  }
+}
+
+.conversation-prompt__label {
+  margin: 0;
+  font-size: 0.63rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-oxblood);
+}
+
+.conversation-prompt__title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.2rem;
+  font-weight: 400;
+  line-height: 1.2;
+}
+
+.conversation-prompt__body {
+  margin: 0;
+  font-size: 0.97rem;
+  line-height: 1.65;
+  color: var(--color-muted);
+}
+
+/* ─── ContactDetails ────────────────────────────────────── */
+
+.contact-details {
+  display: grid;
+  gap: var(--space-24);
+  max-width: 36rem;
+  padding: var(--space-48) 0;
+}
+
+.contact-details__eyebrow {
+  margin: 0;
+  color: var(--color-oxblood);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.68rem;
+  font-weight: 600;
+  line-height: 1.5;
+}
+
+.contact-details__list {
+  border-top: 1px solid var(--color-rule);
+}
+
+.contact-detail-row {
+  display: grid;
+  gap: var(--space-8);
+  padding: var(--space-20) 0;
+  border-bottom: 1px solid var(--color-rule);
+}
+
+.contact-detail-row__label {
+  margin: 0;
+  font-size: 0.63rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.contact-detail-row__link {
+  font-size: 1.1rem;
+  font-weight: 500;
+  color: var(--color-ink);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 180ms ease, color 180ms ease;
+  width: fit-content;
+}
+
+.contact-detail-row__link:hover,
+.contact-detail-row__link:focus-visible {
+  color: var(--color-oxblood);
+  border-bottom-color: var(--color-oxblood);
+}
+
+.contact-detail-row__link:focus-visible {
+  outline: 2px solid var(--color-oxblood);
+  outline-offset: var(--space-4);
+}
+
+/* ─── Contact closing line ──────────────────────────────── */
+
+.contact-closing {
+  margin: 0;
+  padding: var(--space-64) 0;
+  font-family: var(--font-display);
+  font-size: clamp(1.2rem, 2.5vw, 1.8rem);
+  font-style: italic;
+  font-weight: 400;
+  line-height: 1.4;
+  color: var(--color-ink);
+  max-width: 32rem;
+  border-bottom: 1px solid var(--color-rule);
+}


### PR DESCRIPTION
- Rebuild contact.astro with editorial structure: PageIntro, ConversationPrompts, ContactDetails, closing line
- Add optional cta named slot to PageIntro
- Build ConversationPrompts: three-column editorial section with label/title/body
- Build ContactDetails: narrow ruled directory with external-link support
- Fix footer LinkedIn URL to https://www.linkedin.com/in/maggiemlynn/
- Add CSS blocks: .page-intro__cta, .conversation-prompts, .contact-details, .contact-closing